### PR TITLE
Fix the possibility to fetch an empty document

### DIFF
--- a/src/hydra/fetchJsonLd.js
+++ b/src/hydra/fetchJsonLd.js
@@ -22,6 +22,10 @@ export default function fetchJsonLd(url, options = {}) {
 
   return fetch(url, options)
     .then(response => {
+      if (204 === response.status) {
+        return Promise.resolve({ response });
+      }
+
       if (false === response.ok || !response.headers.has('Content-Type') || !response.headers.get('Content-Type').includes(jsonLdMimeType)) {
         return Promise.reject({ response });
       }

--- a/src/hydra/fetchJsonLd.test.js
+++ b/src/hydra/fetchJsonLd.test.js
@@ -42,3 +42,12 @@ test('fetch an error', () => {
     });
   });
 });
+
+test('fetch an empty document', () => {
+  fetch.mockResponseOnce('', {status: 204, statusText: 'No Content', headers: new Headers({'Content-Type': 'text/html'})});
+
+  return fetchJsonLd('/foo.jsonld').then(({response}) => {
+    expect(response.ok).toBe(true);
+    expect(response.body).toBe(undefined);
+  });
+});


### PR DESCRIPTION
From an instance of `api-platform/admin`, I try to delete a resource but I have got an error.

The API response is correct (`204 - No Content`) but `fetchJsonLd` checks if the `Content-Type` is valid. Unfortunately, with `symfony`, an empty response has `text/html` as `Content-Type` value.

In this PR, I added a condition for `204` responses.