### PR TITLE
Reject only 5XX errors

### DIFF
--- a/src/hydra/fetchJsonLd.js
+++ b/src/hydra/fetchJsonLd.js
@@ -22,11 +22,11 @@ export default function fetchJsonLd(url, options = {}) {
 
   return fetch(url, options)
     .then(response => {
-      if (204 === response.status) {
+      const { headers, status } = response;
+      if (204 === status) {
         return Promise.resolve({ response });
       }
-
-      if (false === response.ok || !response.headers.has('Content-Type') || !response.headers.get('Content-Type').includes(jsonLdMimeType)) {
+      if (500 <= status || !headers.has('Content-Type') || !headers.get('Content-Type').includes(jsonLdMimeType)) {
         return Promise.reject({ response });
       }
 

--- a/src/hydra/fetchJsonLd.test.js
+++ b/src/hydra/fetchJsonLd.test.js
@@ -46,8 +46,8 @@ test('fetch an error', () => {
 test('fetch an empty document', () => {
   fetch.mockResponseOnce('', {status: 204, statusText: 'No Content', headers: new Headers({'Content-Type': 'text/html'})});
 
-  return fetchJsonLd('/foo.jsonld').then(({response}) => {
-    expect(response.ok).toBe(true);
-    expect(response.body).toBe(undefined);
+  return fetchJsonLd('/foo.jsonld').then(data => {
+    expect(data.response.ok).toBe(true);
+    expect(data.body).toBe(undefined);
   });
 });


### PR DESCRIPTION
In my previous commit, I added the possibility to reject promise if the response is incorrect. With the  possibility, it was possible to manage authentication.

Unfortunately my commit brokes validations: when `fetchJsonLd` retrieve a `4XX` response, it will reject the promise but in [fetchHydra](https://github.com/api-platform/admin/blob/master/src/hydra/fetchHydra.js#L30), we analyse only resolved promise.

To solve issue [api-platform/admin#68](https://github.com/api-platform/admin/issues/68), I propose to:
* reject only `5XX` errors or non valid response (same behaviors as `fetch`).
* the `4XX` responses will be resolved but parsing will fail so the promise will be reject (no change for `api-platform/admin`).