### PR TITLE
[WIP] Parse supportedOperations into Resource

### DIFF
--- a/src/Operation.js
+++ b/src/Operation.js
@@ -2,8 +2,8 @@
 
 type OperationOptions = {
   method?: string,
-  title?: string,
   returns?: string,
+  types?: Array,
 }
 
 /**

--- a/src/Operation.js
+++ b/src/Operation.js
@@ -1,0 +1,31 @@
+// @flow
+
+type OperationOptions = {
+  method?: string,
+  title?: string,
+  returns?: string,
+}
+
+/**
+ * @property {string} name - The name of this operation
+ */
+export default class Operation {
+  name: string;
+
+  /**
+   * @param {string}            name
+   * @param {?OperationOptions} options
+   */
+  constructor(name: string, options: OperationOptions = {}) {
+    this.name = name;
+
+    Object.keys(options).forEach((key) => {
+      Object.defineProperty(this, key, {
+        readable: true,
+        writable: true,
+        enumerable: true,
+        value: options[key],
+      });
+    });
+  }
+}

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -1,12 +1,14 @@
 // @flow
 
 import Field from './Field';
+import Operation from './Operation';
 
 type ResourceOptions = {
   id?: string,
   title?: string,
   readableFields?: Field[],
   writableFields?: Field[],
+  operations?: Operation[],
 };
 
 /**

--- a/src/hydra/parseHydraDocumentation.test.js
+++ b/src/hydra/parseHydraDocumentation.test.js
@@ -612,6 +612,26 @@ const book = {
       "description": "The date on which the CreativeWork was created or the item was added to a DataFeed",
       "maxCardinality": null,
     }
+  ],
+  "operations": [
+    {
+      "name": "Retrieves Book resource.",
+      "method": "GET",
+      "returns": "http://schema.org/Book",
+      "types": ["http://www.w3.org/ns/hydra/core#Operation"]
+    },
+    {
+      "name": "Replaces the Book resource.",
+      "method": "PUT",
+      "returns": "http://schema.org/Book",
+      "types": ["http://www.w3.org/ns/hydra/core#ReplaceResourceOperation"]
+    },
+    {
+      "name": "Deletes the Book resource.",
+      "method": "DELETE",
+      "returns": "http://www.w3.org/2002/07/owl#Nothing",
+      "types": ["http://www.w3.org/ns/hydra/core#Operation"]
+    }
   ]
 };
 
@@ -711,6 +731,26 @@ const expectedApi = {
           "description": "The item that is being reviewed/rated",
           "maxCardinality": 1,
         }
+      ],
+      "operations": [
+        {
+          "name": "Retrieves Review resource.",
+          "method": "GET",
+          "returns": "http://schema.org/Review",
+          "types": ["http://www.w3.org/ns/hydra/core#Operation"]
+        },
+        {
+          "name": "Replaces the Review resource.",
+          "method": "PUT",
+          "returns": "http://schema.org/Review",
+          "types": ["http://www.w3.org/ns/hydra/core#ReplaceResourceOperation"]
+        },
+        {
+          "name": "Deletes the Review resource.",
+          "method": "DELETE",
+          "returns": "http://www.w3.org/2002/07/owl#Nothing",
+          "types": ["http://www.w3.org/ns/hydra/core#Operation"]
+        }
       ]
     },
     {
@@ -794,6 +834,20 @@ const expectedApi = {
           "required": true,
           "description": "",
           "maxCardinality": null,
+        }
+      ],
+      "operations": [
+        {
+          "name": "Retrieves custom resources.",
+          "method": "GET",
+          "returns": "http://localhost/docs.jsonld#CustomResource",
+          "types": ["http://www.w3.org/ns/hydra/core#Operation"]
+        },
+        {
+          "name": "Creates a custom resource.",
+          "method": "POST",
+          "returns": "http://localhost/docs.jsonld#CustomResource",
+          "types": ["http://www.w3.org/ns/hydra/core#CreateResourceOperation"]
         }
       ]
     }


### PR DESCRIPTION
Hey,

as a user of this lib which consumes an api-platform hydra documentation I'd like to see the contents of the `supportedOperation` entries reflected inside the `Resource` objects which are generated by the `parseHydraDocumentation`.

Background: I've tweaked my API to provide context-sensitive documentation based on the user's privileges - thus, the `supportedOperation` entries are only visible in the api doc when the user is allowed to call that endpoint. To be honest, I did not get very deep into hydra but I hope there's no conceptual violation by using the `supportedOperation` in a context-sensitive manner. I'm pretty aware though that the hydra-documentation can be outdated or a state `supportedOperation` on documentation-read can become _unsupported_ when the user invokes it some moments later.

Why: I want to adjust my SPA in such a way that turns on/off certain functionalities based on those supportedOperations - basically using them as permission based feature flags.

What I did not implement yet is an according parsing of the `hydra:supportedClass#Entrypoint` specs.

Best