### PR TITLE
RFR - Set resource.parameters from query

### DIFF
--- a/src/hydra/getParameters.js
+++ b/src/hydra/getParameters.js
@@ -16,6 +16,7 @@ export default (resource, options = {}, doNotFetchAgain = false) =>
 
           resourceParameters.push(new Parameter(variable, range, required, ""));
         });
+        resource.parameters = resourceParameters;
 
         return resourceParameters;
       });


### PR DESCRIPTION
To avoid making the `getParameters` request several times, update `resource.parameters` with the `fetch`'s return.

This PR is related to https://github.com/coopTilleuls/admin/pull/10