### PR TITLE
Pass options to getParamters

### DIFF
--- a/src/hydra/parseHydraDocumentation.js
+++ b/src/hydra/parseHydraDocumentation.js
@@ -422,7 +422,7 @@ export default function parseHydraDocumentation(entrypointUrl, options = {}) {
 
         resource.parameters = [];
         resource.getParameters = () => {
-          return getParameters(resource);
+          return getParameters(resource, options);
         };
 
         resources.push(resource);


### PR DESCRIPTION
When setting headers (e.g. Authentication) or other options in a custom apiDocumentationParser, those options must be also applied to getParamters