### PR TITLE
Allow writable in Hydra

### DIFF
--- a/src/hydra/parseHydraDocumentation.test.ts
+++ b/src/hydra/parseHydraDocumentation.test.ts
@@ -822,6 +822,28 @@ const book = {
         "The date on which the CreativeWork was created or the item was added to a DataFeed",
       maxCardinality: null,
       deprecated: false
+    },
+    {
+      name: "reviews",
+      id: "http://schema.org/reviews",
+      range: "http://schema.org/Review",
+      reference: "Object http://schema.org/Review",
+      embedded: null,
+      required: false,
+      description: "The book's reviews",
+      maxCardinality: null,
+      deprecated: false
+    },
+    {
+      name: "embeddedReviews",
+      id: "http://schema.org/reviews",
+      range: "http://schema.org/Review",
+      reference: null,
+      embedded: "Object http://schema.org/Review",
+      required: false,
+      description: "The book's reviews",
+      maxCardinality: null,
+      deprecated: false
     }
   ],
   operations: [

--- a/src/hydra/parseHydraDocumentation.ts
+++ b/src/hydra/parseHydraDocumentation.ts
@@ -291,6 +291,10 @@ export default function parseHydraDocumentation(
             get(
               supportedProperties,
               '["http://www.w3.org/ns/hydra/core#writeable"][0]["@value"]'
+            ) ||
+            get(
+              supportedProperties,
+              '["http://www.w3.org/ns/hydra/core#writable"][0]["@value"]'
             )
           ) {
             writableFields.push(field);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Following https://github.com/api-platform/api-doc-parser/pull/78.
Allow `writable` to not break everything...