### PR TITLE
fix: ignore {id} routes in handleJson

### DIFF
--- a/src/openapi3/handleJson.ts
+++ b/src/openapi3/handleJson.ts
@@ -1,5 +1,4 @@
 import get from "lodash.get";
-import uniq from "lodash.uniq";
 import { OpenAPIV3 } from "openapi-types";
 import { Field } from "../Field";
 import { Resource } from "../Resource";
@@ -15,8 +14,8 @@ export default function(
   response: OpenAPIV3.Document,
   entrypointUrl: string
 ): Resource[] {
-  const paths = uniq(
-    Object.keys(response.paths).map(item => item.replace(`/{id}`, ``))
+  const paths = Object.keys(response.paths).filter(
+    item => !item.includes(`/{id}`)
   );
 
   const resources = paths.map(item => {

--- a/src/swagger/handleJson.ts
+++ b/src/swagger/handleJson.ts
@@ -1,5 +1,4 @@
 import get from "lodash.get";
-import uniq from "lodash.uniq";
 import { OpenAPIV2 } from "openapi-types";
 import { Field } from "../Field";
 import { Resource } from "../Resource";
@@ -15,8 +14,8 @@ export default function(
   response: OpenAPIV2.Document,
   entrypointUrl: string
 ): Resource[] {
-  const paths = uniq(
-    Object.keys(response.paths).map(item => item.replace(`/{id}`, ``))
+  const paths = Object.keys(response.paths).filter(
+    item => !item.includes(`/{id}`)
   );
 
   const resources = paths.map(item => {


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #76 
| License       | MIT

Currently this lib breaks on the example in the README.  The issue is that in `handleJson`, `paths` was trying to create a unique array of resource paths with `/{id}` stripped from every path.

Fine when your paths are simply `/books` and `/books/{id}`, but https://demo.api-platform.com/docs.json?spec_version=3 includes `/books/{id}/generate-cover`, which shortens to `/books/generate-cover`, which isn't a valid resource key.

I'd suggest someone familiar with this confirms this approach makes sense, as I wasn't completely sure what the intention behind this type of handling is.  E.g. if I have a path `/register`, that won't get stripped out, even though it's not really a "Resource" (more like an alias for `POST /users`).  But at least this fix doesn't make the situation worse, as before `/register` would have already been included.

cc @soyuka who was asking for more info in the linked issue.