### PR TITLE
Remove fetchResource 'Unreachable resource' error override

### DIFF
--- a/src/hydra/fetchResource.ts
+++ b/src/hydra/fetchResource.ts
@@ -8,12 +8,7 @@ export default (
   return fetchJsonLd(
     resourceUrl,
     Object.assign({ itemsPerPage: 0 }, options)
-  ).then(
-    d => ({
-      parameters: get(d, "body.hydra:search.hydra:mapping")
-    }),
-    () => {
-      throw new Error("Unreachable resource");
-    }
-  );
+  ).then(d => ({
+    parameters: get(d, "body.hydra:search.hydra:mapping")
+  }));
 };


### PR DESCRIPTION
Override is useless and lead to complex `checkError()` behavior, `fetchJsonLd` already throw `{ resource }` object

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

`fetchResource` should not override default `fetchJsonLd` throwed error to have a consistent `checkError()` on `react-admin`
