### PR TITLE
Add function headers behavior

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 7,
     sourceType: "module",
-    project: ["./tsconfig.json"]
+    project: ["./tsconfig.eslint.json"]
   },
   plugins: ["@typescript-eslint"],
 

--- a/src/hydra/fetchJsonLd.ts
+++ b/src/hydra/fetchJsonLd.ts
@@ -5,7 +5,7 @@ const jsonLdMimeType = "application/ld+json";
  */
 export default async function fetchJsonLd(
   url: string,
-  options: RequestInit = {}
+  options: RequestInitExtended = {}
 ): Promise<{
   response: Response;
   body?: any;
@@ -25,22 +25,28 @@ export default async function fetchJsonLd(
   return response.json().then(body => ({ response, body, document: body }));
 }
 
-function setHeaders(options: RequestInit): RequestInit {
-  if (!(options.headers instanceof Headers)) {
-    options.headers = new Headers(options.headers);
+function setHeaders(options: RequestInitExtended): RequestInit {
+  const result = { ...options };
+
+  if (typeof result.headers === "function") {
+    result.headers = result.headers();
   }
 
-  if (null === options.headers.get("Accept")) {
-    options.headers.set("Accept", jsonLdMimeType);
+  if (!(result.headers instanceof Headers)) {
+    result.headers = new Headers(result.headers as HeadersInit);
+  }
+
+  if (null === result.headers.get("Accept")) {
+    result.headers.set("Accept", jsonLdMimeType);
   }
 
   if (
-    "undefined" !== options.body &&
-    !(typeof FormData !== "undefined" && options.body instanceof FormData) &&
-    null === options.headers.get("Content-Type")
+    "undefined" !== result.body &&
+    !(typeof FormData !== "undefined" && result.body instanceof FormData) &&
+    null === result.headers.get("Content-Type")
   ) {
-    options.headers.set("Content-Type", jsonLdMimeType);
+    result.headers.set("Content-Type", jsonLdMimeType);
   }
 
-  return options;
+  return result as RequestInit;
 }

--- a/src/hydra/fetchJsonLd.ts
+++ b/src/hydra/fetchJsonLd.ts
@@ -1,3 +1,5 @@
+import { RequestInitExtended } from "./types";
+
 const jsonLdMimeType = "application/ld+json";
 
 /**
@@ -26,19 +28,20 @@ export default async function fetchJsonLd(
 }
 
 function setHeaders(options: RequestInitExtended): RequestInit {
-  const result = { ...options };
-
-  if (typeof result.headers === "function") {
-    result.headers = result.headers();
+  if (!options.headers) {
+    return { ...options, headers: {} };
   }
 
-  if (!(result.headers instanceof Headers)) {
-    result.headers = new Headers(result.headers as HeadersInit);
+  let headers: HeadersInit =
+    typeof options.headers === "function" ? options.headers() : options.headers;
+
+  headers = new Headers(headers);
+
+  if (null === headers.get("Accept")) {
+    headers.set("Accept", jsonLdMimeType);
   }
 
-  if (null === result.headers.get("Accept")) {
-    result.headers.set("Accept", jsonLdMimeType);
-  }
+  const result = { ...options, headers };
 
   if (
     "undefined" !== result.body &&
@@ -48,5 +51,5 @@ function setHeaders(options: RequestInitExtended): RequestInit {
     result.headers.set("Content-Type", jsonLdMimeType);
   }
 
-  return result as RequestInit;
+  return result;
 }

--- a/src/hydra/fetchResource.ts
+++ b/src/hydra/fetchResource.ts
@@ -3,7 +3,7 @@ import fetchJsonLd from "./fetchJsonLd";
 
 export default (
   resourceUrl: string,
-  options: RequestInit = {}
+  options: RequestInitExtended = {}
 ): Promise<any> => {
   return fetchJsonLd(
     resourceUrl,

--- a/src/hydra/fetchResource.ts
+++ b/src/hydra/fetchResource.ts
@@ -1,5 +1,6 @@
 import get from "lodash.get";
 import fetchJsonLd from "./fetchJsonLd";
+import { RequestInitExtended } from "./types";
 
 export default (
   resourceUrl: string,

--- a/src/hydra/getParameters.ts
+++ b/src/hydra/getParameters.ts
@@ -1,8 +1,12 @@
 import { Parameter } from "../Parameter";
 import { Resource } from "../Resource";
 import fetchResource from "./fetchResource";
+import { RequestInitExtended } from "./types";
 
-export default (resource: Resource, options = {}): Promise<Parameter[]> =>
+export default (
+  resource: Resource,
+  options: RequestInitExtended = {}
+): Promise<Parameter[]> =>
   fetchResource(resource.url, options).then(({ parameters = [] }) => {
     const resourceParameters: Parameter[] = [];
     parameters.forEach(({ property = null, required, variable }: any) => {

--- a/src/hydra/parseHydraDocumentation.test.ts
+++ b/src/hydra/parseHydraDocumentation.test.ts
@@ -1277,6 +1277,32 @@ test("parse a Hydra documentation", async () => {
   });
 });
 
+test("parse a Hydra documentation using a dynamic headers", async () => {
+  fetchMock.mockResponses([entrypoint, init], [docs, init]);
+
+  const getHeaders = (): Headers =>
+    new Headers({ CustomHeader: "customValue" });
+
+  await parseHydraDocumentation("http://localhost", {
+    headers: getHeaders
+  }).then(data => {
+    expect(JSON.stringify(data.api, apiJsonReplacer, 2)).toBe(
+      JSON.stringify(expectedApi, null, 2)
+    );
+    expect(data.response).toBeDefined();
+    expect(data.status).toBe(200);
+
+    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(fetch).toHaveBeenNthCalledWith(2, "http://localhost/docs.jsonld", {
+      headers: new Headers({
+        CustomHeader: "customValue",
+        Accept: "application/ld+json",
+        "Content-Type": "application/ld+json"
+      })
+    });
+  });
+});
+
 test("parse a Hydra documentation (http://localhost/)", async () => {
   fetchMock.mockResponses([entrypoint, init], [docs, init]);
 

--- a/src/hydra/parseHydraDocumentation.test.ts
+++ b/src/hydra/parseHydraDocumentation.test.ts
@@ -1269,15 +1269,17 @@ test("parse a Hydra documentation", async () => {
     expect(data.status).toBe(200);
 
     expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).toHaveBeenNthCalledWith(
-      2,
-      "http://localhost/docs.jsonld",
-      options
-    );
+    expect(fetch).toHaveBeenNthCalledWith(2, "http://localhost/docs.jsonld", {
+      headers: new Headers({
+        Accept: "application/ld+json",
+        "Content-Type": "application/ld+json",
+        CustomHeader: "customValue"
+      })
+    });
   });
 });
 
-test("parse a Hydra documentation using a dynamic headers", async () => {
+test("parse a Hydra documentation using dynamic headers", async () => {
   fetchMock.mockResponses([entrypoint, init], [docs, init]);
 
   const getHeaders = (): Headers =>

--- a/src/hydra/parseHydraDocumentation.ts
+++ b/src/hydra/parseHydraDocumentation.ts
@@ -66,7 +66,7 @@ export function getDocumentationUrlFromHeaders(headers: Headers): string {
  */
 async function fetchEntrypointAndDocs(
   entrypointUrl: string,
-  options: RequestInit = {}
+  options: RequestInitExtended = {}
 ): Promise<{
   entrypointUrl: string;
   docsUrl: string;
@@ -168,7 +168,7 @@ function findRelatedClass(
  */
 export default function parseHydraDocumentation(
   entrypointUrl: string,
-  options: RequestInit = {}
+  options: RequestInitExtended = {}
 ): Promise<{
   api: Api;
   response: Response;

--- a/src/hydra/parseHydraDocumentation.ts
+++ b/src/hydra/parseHydraDocumentation.ts
@@ -7,6 +7,7 @@ import { Operation } from "../Operation";
 import { Parameter } from "../Parameter";
 import fetchJsonLd from "./fetchJsonLd";
 import getParameters from "./getParameters";
+import { RequestInitExtended } from "./types";
 
 /**
  * Extracts the short name of a resource.

--- a/src/hydra/types.ts
+++ b/src/hydra/types.ts
@@ -1,3 +1,3 @@
-interface RequestInitExtended extends Omit<RequestInit, "headers"> {
-  headers?: HeadersInit | Function;
+export interface RequestInitExtended extends Omit<RequestInit, "headers"> {
+  headers?: HeadersInit | (() => HeadersInit);
 }

--- a/src/hydra/types.ts
+++ b/src/hydra/types.ts
@@ -1,0 +1,3 @@
+interface RequestInitExtended extends Omit<RequestInit, "headers"> {
+  headers?: HeadersInit | Function;
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,8 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "typeRoots": ["node_modules/@types", "@types"]
-  }
+  },
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
Allow users to give a function for `headers` key in `parseHydraDocumentation` options

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Else, on an authenticated `react-admin` application using a `JWT`, when this one is `expired` you're logged out, once `logged` again, the first request still use old configured `headers`