### PR TITLE
Extend OpenAPI3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "graphql": "^15.0.0",
+    "json-refs": "^3.0.15",
     "jsonld": "^3.2.0",
     "lodash.get": "^4.4.2",
     "tslib": "^2.0.0"

--- a/src/openapi3/handleJson.test.ts
+++ b/src/openapi3/handleJson.test.ts
@@ -567,6 +567,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -575,6 +576,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "The ISBN of the book",
       },
       {
@@ -583,6 +585,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description: "A description of the item",
       },
       {
@@ -591,6 +594,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description:
           "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
       },
@@ -600,6 +604,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description: "The title of the book",
       },
       {
@@ -608,6 +613,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description:
           "The date on which the CreativeWork was created or the item was added to a DataFeed",
       },
@@ -619,6 +625,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -627,6 +634,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "The ISBN of the book",
       },
       {
@@ -635,6 +643,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description: "A description of the item",
       },
       {
@@ -643,6 +652,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description:
           "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
       },
@@ -652,6 +662,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description: "The title of the book",
       },
       {
@@ -660,6 +671,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description:
           "The date on which the CreativeWork was created or the item was added to a DataFeed",
       },
@@ -671,6 +683,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -679,6 +692,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "The ISBN of the book",
       },
       {
@@ -687,6 +701,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description: "A description of the item",
       },
       {
@@ -695,6 +710,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description:
           "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
       },
@@ -704,6 +720,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description: "The title of the book",
       },
       {
@@ -712,6 +729,7 @@ const parsed = [
         range: null,
         reference: null,
         required: true,
+        embedded: null,
         description:
           "The date on which the CreativeWork was created or the item was added to a DataFeed",
       },
@@ -729,6 +747,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -737,6 +756,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -745,6 +765,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "The actual body of the review",
       },
       {
@@ -763,6 +784,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -771,6 +793,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -779,6 +802,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -787,6 +811,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -796,6 +821,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -804,6 +830,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -815,6 +842,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -823,6 +851,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -831,6 +860,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -839,6 +869,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -848,6 +879,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -856,6 +888,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -867,6 +900,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -875,6 +909,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -883,6 +918,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -891,6 +927,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -900,6 +937,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -908,6 +946,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -922,6 +961,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "Author the author of the review",
       },
       {
@@ -930,6 +970,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "Author the author of the review",
       },
     ],
@@ -940,6 +981,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -948,6 +990,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -956,6 +999,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "The actual body of the review",
       },
       {
@@ -974,6 +1018,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -982,6 +1027,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -990,6 +1036,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -998,6 +1045,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -1007,6 +1055,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -1015,6 +1064,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -1026,6 +1076,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -1034,6 +1085,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -1042,6 +1094,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -1050,6 +1103,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -1059,6 +1113,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -1067,6 +1122,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -1078,6 +1134,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -1086,6 +1143,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -1094,6 +1152,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -1102,6 +1161,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -1111,6 +1171,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -1119,6 +1180,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -1133,6 +1195,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "Author the author of the review",
       },
       {
@@ -1141,6 +1204,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "Author the author of the review",
       },
     ],
@@ -1151,6 +1215,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -1159,6 +1224,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "",
       },
       {
@@ -1167,6 +1233,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "The actual body of the review",
       },
       {
@@ -1185,6 +1252,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -1193,6 +1261,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -1201,6 +1270,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -1209,6 +1279,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -1218,6 +1289,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -1226,6 +1298,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -1237,6 +1310,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -1245,6 +1319,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -1253,6 +1328,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -1261,6 +1337,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -1270,6 +1347,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -1278,6 +1356,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -1289,6 +1368,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "",
             },
             {
@@ -1297,6 +1377,7 @@ const parsed = [
               range: null,
               reference: null,
               required: false,
+              embedded: null,
               description: "The ISBN of the book",
             },
             {
@@ -1305,6 +1386,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "A description of the item",
             },
             {
@@ -1313,6 +1395,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably",
             },
@@ -1322,6 +1405,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description: "The title of the book",
             },
             {
@@ -1330,6 +1414,7 @@ const parsed = [
               range: null,
               reference: null,
               required: true,
+              embedded: null,
               description:
                 "The date on which the CreativeWork was created or the item was added to a DataFeed",
             },
@@ -1344,6 +1429,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "Author the author of the review",
       },
       {
@@ -1352,6 +1438,7 @@ const parsed = [
         range: null,
         reference: null,
         required: false,
+        embedded: null,
         description: "Author the author of the review",
       },
     ],
@@ -1359,12 +1446,12 @@ const parsed = [
 ];
 
 describe(`Parse OpenApi v3 Documentation from Json`, () => {
-  const toBeParsed = handleJson(
-    openApi3Definition,
-    "https://demo.api-platform.com"
-  );
-
-  test(`Properties to be equal`, () => {
+  test(`Properties to be equal`, async () => {
+    const toBeParsed = await handleJson(
+      openApi3Definition,
+      "https://demo.api-platform.com"
+    );
+  
     expect(toBeParsed[0].name).toBe(parsed[0].name);
     expect(toBeParsed[0].url).toBe(parsed[0].url);
     expect(toBeParsed[0].id).toBe(parsed[0].id);

--- a/src/openapi3/handleJson.test.ts
+++ b/src/openapi3/handleJson.test.ts
@@ -1451,7 +1451,7 @@ describe(`Parse OpenApi v3 Documentation from Json`, () => {
       openApi3Definition,
       "https://demo.api-platform.com"
     );
-  
+
     expect(toBeParsed[0].name).toBe(parsed[0].name);
     expect(toBeParsed[0].url).toBe(parsed[0].url);
     expect(toBeParsed[0].id).toBe(parsed[0].id);

--- a/src/openapi3/handleJson.test.ts
+++ b/src/openapi3/handleJson.test.ts
@@ -1456,7 +1456,7 @@ describe(`Parse OpenApi v3 Documentation from Json`, () => {
     expect(toBeParsed[0].url).toBe(parsed[0].url);
     expect(toBeParsed[0].id).toBe(parsed[0].id);
 
-    expect((toBeParsed[0].fields as Field[])[0]).toEqual(parsed[0].fields[0]);
+    expect(toBeParsed[0].fields?.[0]).toEqual(parsed[0].fields[0]);
 
     expect(toBeParsed[1].name).toBe(parsed[1].name);
     expect(toBeParsed[1].url).toBe(parsed[1].url);

--- a/src/openapi3/handleJson.test.ts
+++ b/src/openapi3/handleJson.test.ts
@@ -1456,6 +1456,8 @@ describe(`Parse OpenApi v3 Documentation from Json`, () => {
     expect(toBeParsed[0].url).toBe(parsed[0].url);
     expect(toBeParsed[0].id).toBe(parsed[0].id);
 
+    expect((toBeParsed[0].fields as Field[])[0]).toEqual(parsed[0].fields[0]);
+
     expect(toBeParsed[1].name).toBe(parsed[1].name);
     expect(toBeParsed[1].url).toBe(parsed[1].url);
     expect(toBeParsed[1].id).toBe(parsed[1].id);

--- a/src/openapi3/handleJson.ts
+++ b/src/openapi3/handleJson.ts
@@ -82,7 +82,7 @@ export default async function (
     resources.push(
       new Resource(name, url, {
         id: null,
-        title: title,
+        title,
         fields,
         readableFields: fields,
         writableFields: fields,

--- a/src/openapi3/handleJson.ts
+++ b/src/openapi3/handleJson.ts
@@ -3,7 +3,7 @@ import { OpenAPIV3 } from "openapi-types";
 import { Field } from "../Field";
 import { Resource } from "../Resource";
 import { getResources } from "../utils/getResources";
-import jsonRefs, { ResolvedRefsResults } from "json-refs";
+import jsonRefs from "json-refs";
 
 export const removeTrailingSlash = (url: string): string => {
   if (url.endsWith("/")) {
@@ -13,12 +13,12 @@ export const removeTrailingSlash = (url: string): string => {
 };
 
 /* Assumptions:
-  RESTful APIs typically have two paths per resources -  a `/noun` path and a 
+  RESTful APIs typically have two paths per resources:  a `/noun` path and a 
   `/noun/{id}` path. `getResources` strips out the latter, allowing us to focus
   on the former.
 
-  In OpenAPI3, the `/noun` path will typically have a `get` action, that 
-  probably accepts parameters and would respond with a array of objects, 
+  In OpenAPI 3, the `/noun` path will typically have a `get` action, that 
+  probably accepts parameters and would respond with an array of objects, 
   described in the `items` field.
 */
 
@@ -26,8 +26,8 @@ export default async function (
   response: OpenAPIV3.Document,
   entrypointUrl: string
 ): Promise<Resource[]> {
-  const results: ResolvedRefsResults = await jsonRefs.resolveRefs(response);
-  const document: OpenAPIV3.Document = results.resolved as OpenAPIV3.Document;
+  const results = await jsonRefs.resolveRefs(response);
+  const document = results.resolved as OpenAPIV3.Document;
 
   const paths = getResources(document.paths);
 
@@ -45,8 +45,9 @@ export default async function (
     const url = removeTrailingSlash(serverUrl) + item;
 
     const method = document.paths[item].get as OpenAPIV3.OperationObject;
-
     if (!method) return;
+
+    const title = get(method, ["tags", "0"], name) as string;
 
     const schema = get(
       method,
@@ -81,7 +82,7 @@ export default async function (
     resources.push(
       new Resource(name, url, {
         id: null,
-        title: "title",
+        title: title,
         fields,
         readableFields: fields,
         writableFields: fields,

--- a/src/openapi3/handleJson.ts
+++ b/src/openapi3/handleJson.ts
@@ -2,9 +2,8 @@ import get from "lodash.get";
 import { OpenAPIV3 } from "openapi-types";
 import { Field } from "../Field";
 import { Resource } from "../Resource";
-import { Parameter } from "../Parameter";
 import { getResources } from "../utils/getResources";
-import jsonRefs, { ResolvedRefsResults } from 'json-refs';
+import jsonRefs, { ResolvedRefsResults } from "json-refs";
 
 export const removeTrailingSlash = (url: string): string => {
   if (url.endsWith("/")) {
@@ -40,17 +39,17 @@ export default async function (
   const serverUrl = new URL(serverUrlOrRelative, entrypointUrl).href;
 
   const resources: Resource[] = [];
-  
+
   paths.forEach((item) => {
     const name = item.replace(`/`, ``);
     const url = removeTrailingSlash(serverUrl) + item;
 
     const method = document.paths[item].get as OpenAPIV3.OperationObject;
-    
+
     if (!method) return;
 
     const schema = get(
-      method, 
+      method,
       "responses.200.content.application/json.schema"
     ) as OpenAPIV3.ArraySchemaObject;
 
@@ -65,11 +64,7 @@ export default async function (
     }
 
     const fieldNames = Object.keys(properties);
-    const requiredFields = get(
-      schema,
-      "items.required",
-      []
-    ) as string[];
+    const requiredFields = get(schema, "items.required", []) as string[];
 
     const fields = fieldNames.map(
       (fieldName) =>
@@ -83,15 +78,17 @@ export default async function (
         })
     );
 
-    resources.push(new Resource(name, url, {
-      id: null,
-      title: "title",
-      fields,
-      readableFields: fields,
-      writableFields: fields,
-      parameters: [],
-      getParameters: () => Promise.resolve([])
-    }));
+    resources.push(
+      new Resource(name, url, {
+        id: null,
+        title: "title",
+        fields,
+        readableFields: fields,
+        writableFields: fields,
+        parameters: [],
+        getParameters: () => Promise.resolve([]),
+      })
+    );
   });
 
   return resources;

--- a/src/openapi3/handleJson.ts
+++ b/src/openapi3/handleJson.ts
@@ -19,7 +19,8 @@ export const removeTrailingSlash = (url: string): string => {
   on the former.
 
   In OpenAPI3, the `/noun` path will typically have a `get` action, that 
-  probably accepts parameters and would respond with a array of objects.
+  probably accepts parameters and would respond with a array of objects, 
+  described in the `items` field.
 */
 
 export default async function (
@@ -65,8 +66,8 @@ export default async function (
 
     const fieldNames = Object.keys(properties);
     const requiredFields = get(
-      document,
-      ["components", "schemas", "title", "required"],
+      schema,
+      "items.required",
       []
     ) as string[];
 

--- a/src/openapi3/parseOpenApi3Documentation.ts
+++ b/src/openapi3/parseOpenApi3Documentation.ts
@@ -17,13 +17,12 @@ export default function parseOpenApi3Documentation(
     .then(
       ([res, response]: [res: Response, response: OpenAPIV3.Document]) => {
         const title = response.info.title;
-        const resources = handleJson(response, entrypointUrl);
-
-        return Promise.resolve({
+        return handleJson(response, entrypointUrl)
+        .then(resources => ({
           api: new Api(entrypointUrl, { title, resources }),
           response,
           status: res.status,
-        });
+        }))
       },
       ([res, response]: [res: Response, response: OpenAPIV3.Document]) =>
         Promise.reject({

--- a/src/openapi3/parseOpenApi3Documentation.ts
+++ b/src/openapi3/parseOpenApi3Documentation.ts
@@ -17,12 +17,11 @@ export default function parseOpenApi3Documentation(
     .then(
       ([res, response]: [res: Response, response: OpenAPIV3.Document]) => {
         const title = response.info.title;
-        return handleJson(response, entrypointUrl)
-        .then(resources => ({
+        return handleJson(response, entrypointUrl).then((resources) => ({
           api: new Api(entrypointUrl, { title, resources }),
           response,
           status: res.status,
-        }))
+        }));
       },
       ([res, response]: [res: Response, response: OpenAPIV3.Document]) =>
         Promise.reject({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "typeRoots": ["node_modules/@types", "@types"]
   },
   "exclude": [
-    "src/**/*.test.ts"
+    "src/**/*.test.ts",
+    "lib/*"
   ]
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | ?
| Tickets       | fixes #37 
| License       | MIT
| Doc PR        | api-platform/docs#...

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->

To get [API Platform's Admin](https://github.com/api-platform/admin) working in my project I needed OpenAPI3 support; the current parsing code didn't work for me so I've been experimentally writing some that lines up a bit closer with the [https://swagger.io/specification/](OpenAPI3 spec).

I've tried to document my assumptions - the OpenAPI3 doesn't really represent 'resources', exactly, so there's quite a bit of translation involved. I pulled in an external library to deal with the '$ref' mechanism used in the spec; I've also added some field attributes like 'embedded' that the Admin code seemed to need.

I haven't yet explored types etc much - this PR is mainly to test the waters on my approach, and the receptivity of the team for this kind of change.

Thanks for the library. :)

PS. I added 'lib' to the `tsconfig.json` 'cause I was getting warnings about overwriting the type files. I'm not very experienced with TypeScript but this seemed to fix the problem.
