### PR TITLE
Use better error message when the resource is not found in the entrypoint

### DIFF
--- a/src/hydra/parseHydraDocumentation.ts
+++ b/src/hydra/parseHydraDocumentation.ts
@@ -406,7 +406,7 @@ export default function parseHydraDocumentation(
           | undefined;
         if (!url) {
           throw new Error(
-            `Unable to find the URL for "${property["@id"]}", make sure your api resource has at least one GET item operation declared.`
+            `Unable to find the URL for "${property["@id"]}" in the entrypoint, make sure your API resource has at least one GET collection operation declared.`
           );
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The resource needs to have a GET collection operation to appear in the entrypoint, not an item one.