### PR TITLE
Export both ESM and CJS for treeshaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,21 @@ If you plan to use the library with Node, you also need a polyfill for the `fetc
 
 **Hydra**
 ```javascript
-import parseHydraDocumentation from '@api-platform/api-doc-parser/lib/hydra/parseHydraDocumentation';
+import { parseHydraDocumentation } from '@api-platform/api-doc-parser';
 
 parseHydraDocumentation('https://demo.api-platform.com').then(({api}) => console.log(api));
 ```
 
 **OpenAPI v2 (formerly known as Swagger)**
 ```javascript
-import parseSwaggerDocumentation from '@api-platform/api-doc-parser/lib/swagger/parseSwaggerDocumentation';
+import { parseSwaggerDocumentation } from '@api-platform/api-doc-parser';
 
 parseSwaggerDocumentation('https://demo.api-platform.com/docs.json').then(({api}) => console.log(api));
 ```
 
 **OpenAPI v3**
 ```javascript
-import parseOpenApi3Documentation from '@api-platform/api-doc-parser/lib/openapi3/parseOpenApi3Documentation';
+import { parseOpenApi3Documentation } from '@api-platform/api-doc-parser';
 
 parseOpenApi3Documentation('https://demo.api-platform.com/docs.json?spec_version=3').then(({api}) => console.log(api));
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lib",
     "src"
   ],
-  "main": "lib/index",
+  "main": "lib/cjs/index",
+  "module": "lib/esm/index",
   "repository": "api-platform/api-doc-parser",
   "homepage": "https://github.com/api-platform/api-doc-parser",
   "bugs": "https://github.com/api-platform/api-doc-parser/issues",
@@ -43,9 +44,10 @@
     "lint": "esw --color src --ext .ts",
     "fix": "yarn lint --fix",
     "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
-    "build": "tsc",
+    "build": "rm -rf lib/* && tsc && tsc -p tsconfig.esm.json",
     "watch": "tsc --watch"
   },
+  "sideEffects": false,
   "jest": {
     "automock": false,
     "setupFiles": [

--- a/src/openapi3/handleJson.ts
+++ b/src/openapi3/handleJson.ts
@@ -20,10 +20,15 @@ export default function (
   const resources = paths.map((item) => {
     const name = item.replace(`/`, ``);
     const url = removeTrailingSlash(entrypointUrl) + item;
+    const currentItem = response.paths[item];
+    if (!currentItem) {
+      throw new Error();
+    }
+
     const firstMethod = Object.keys(
-      response.paths[item]
+      currentItem
     )[0] as keyof OpenAPIV3.PathItemObject;
-    const responsePathItem = response.paths[item][
+    const responsePathItem = currentItem[
       firstMethod
     ] as OpenAPIV3.OperationObject;
 

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es6",
+    "module": "esnext",
+    "outDir": "./lib/esm",
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "sourceMap": true,
-    "outDir": "./lib",
+    "outDir": "./lib/cjs",
     "declaration": true,
     "declarationMap": true,
     "rootDir": "./src",
@@ -14,6 +14,7 @@
     "typeRoots": ["node_modules/@types", "@types"]
   },
   "exclude": [
-    "src/**/*.test.ts"
+    "src/**/*.test.ts",
+    "lib/*"
   ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      |  no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        |

Hi!

I recently used @api-platform/admin on a project. Great starter for an admin!
I noticed that this library is not tree-shakeable. This means that even if I am not using graphql endpoints, the graphql library will be bundled and downloaded by the users. It is a whopping 43kb gzipped (see https://bundlephobia.com/result?p=graphql@15.0.0)!

I tried to embed both CJS and ESM builds in one package, with scoped exports to allow both node and a browser/webpack to find the correct package. Let me know if I missed something.

I tried a couple of builds: this reduces the gzipped bundled size by around 40kb when using an hydra endoint and up to 86kb when using a graphql endpoint.

Something nice if we want to continue in that direction would be to upgrade jsonld to `^5.0.0`, they also generated an ESM version (https://github.com/digitalbazaar/jsonld.js/blob/master/CHANGELOG.md#added).

Please let me know if I need to change anything.