### PR TITLE
fix: use RemoteDocument for fetchJsonLd response

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "prettier/@typescript-eslint",
+    "prettier",
     "plugin:prettier/recommended"
   ],
 

--- a/src/hydra/fetchJsonLd.test.ts
+++ b/src/hydra/fetchJsonLd.test.ts
@@ -1,5 +1,5 @@
 import { FetchMock } from "jest-fetch-mock";
-import fetchJsonLd from "./fetchJsonLd";
+import fetchJsonLd, { RejectedResponseDocument } from "./fetchJsonLd";
 
 const fetchMock = fetch as FetchMock;
 
@@ -73,8 +73,7 @@ test("fetch an empty document", () => {
     headers: { "Content-Type": "text/html" },
   });
 
-  return fetchJsonLd("/foo.jsonld").then((data) => {
+  return fetchJsonLd("/foo.jsonld").catch((data: RejectedResponseDocument) => {
     expect(data.response.ok).toBe(true);
-    expect(data.body).toBe(undefined);
   });
 });

--- a/src/hydra/parseHydraDocumentation.test.ts
+++ b/src/hydra/parseHydraDocumentation.test.ts
@@ -1239,8 +1239,7 @@ const init: MockParams = {
   status: 200,
   statusText: "OK",
   headers: {
-    Link:
-      '<http://localhost/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"',
+    Link: '<http://localhost/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"',
     "Content-Type": "application/ld+json",
   },
 };

--- a/src/hydra/parseHydraDocumentation.ts
+++ b/src/hydra/parseHydraDocumentation.ts
@@ -53,9 +53,10 @@ export function getDocumentationUrlFromHeaders(headers: Headers): string {
     throw new Error('The response has no "Link" HTTP header.');
   }
 
-  const matches = /<(.+)>; rel="http:\/\/www.w3.org\/ns\/hydra\/core#apiDocumentation"/.exec(
-    linkHeader
-  );
+  const matches =
+    /<(.+)>; rel="http:\/\/www.w3.org\/ns\/hydra\/core#apiDocumentation"/.exec(
+      linkHeader
+    );
   if (matches === null) {
     throw new Error(
       'The "Link" HTTP header is not of the type "http://www.w3.org/ns/hydra/core#apiDocumentation".'
@@ -79,26 +80,13 @@ async function fetchEntrypointAndDocs(
   docs: Doc[];
 }> {
   const d = await fetchJsonLd(entrypointUrl, options);
-  if (!d.body) {
-    throw new Error(
-      `Entrypoint ${entrypointUrl} is not a valid JSON-LD document.`
-    );
-  }
   const docsUrl = getDocumentationUrlFromHeaders(d.response.headers);
 
-  // @TODO this is suspect according to the jsonld type defs
-  const documentLoader = (input: string): Promise<any /* RemoteDocument */> =>
-    fetchJsonLd(input, options);
+  const documentLoader = (input: string) => fetchJsonLd(input, options);
 
   const docsJsonLd = (await fetchJsonLd(docsUrl, options)).body;
 
-  if (!docsJsonLd) {
-    throw new Error(
-      `Docs endpoint ${docsUrl} is not a valid JSON-LD document.`
-    );
-  }
-
-  const [docs, entrypoint] = ((await Promise.all([
+  const [docs, entrypoint] = (await Promise.all([
     jsonld.expand(docsJsonLd, {
       base: docsUrl,
       documentLoader,
@@ -107,7 +95,7 @@ async function fetchEntrypointAndDocs(
       base: entrypointUrl,
       documentLoader,
     }),
-  ])) as unknown) as [Doc[], Entrypoint[]];
+  ])) as unknown as [Doc[], Entrypoint[]];
 
   return {
     entrypointUrl,
@@ -264,7 +252,7 @@ export default function parseHydraDocumentation(
               embedded:
                 "http://www.w3.org/ns/hydra/core#Link" !==
                 get(supportedProperty, '["@type"][0]')
-                  ? ((range as unknown) as Resource) // Will be updated in a subsequent pass
+                  ? (range as unknown as Resource) // Will be updated in a subsequent pass
                   : null,
               required: get(
                 supportedProperties,

--- a/src/swagger/handleJson.ts
+++ b/src/swagger/handleJson.ts
@@ -23,7 +23,7 @@ export default function (
     const firstMethod = Object.keys(
       response.paths[item]
     )[0] as keyof OpenAPIV2.PathItemObject;
-    const responsePathItem = (response.paths[item] as OpenAPIV2.PathItemObject)[
+    const responsePathItem = response.paths[item][
       firstMethod
     ] as OpenAPIV2.OperationObject;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The behavior of fetchJsonLd when an empty response (204) is received has been changed: instead of resolving the promise, the promise is now rejected.