### PR TITLE
fix: use jsonref instead of json-refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "dependencies": {
     "graphql": "^16.0.0",
     "inflection": "^1.13.0",
-    "json-refs": "^3.0.0",
     "jsonld": "^5.2.0",
+    "jsonref": "^7.0.0",
     "lodash.get": "^4.4.0",
     "tslib": "^2.0.0"
   },

--- a/src/openapi3/handleJson.ts
+++ b/src/openapi3/handleJson.ts
@@ -1,5 +1,5 @@
 import { OpenAPIV3 } from "openapi-types";
-import jsonRefs from "json-refs";
+import { parse as dereference } from "jsonref";
 import get from "lodash.get";
 import { camelize, classify, pluralize } from "inflection";
 import { Field } from "../Field";
@@ -127,8 +127,9 @@ export default async function (
   response: OpenAPIV3.Document,
   entrypointUrl: string
 ): Promise<Resource[]> {
-  const results = await jsonRefs.resolveRefs(response);
-  const document = results.resolved as OpenAPIV3.Document;
+  const document = (await dereference(response, {
+    scope: entrypointUrl,
+  })) as OpenAPIV3.Document;
 
   const paths = getResourcePaths(document.paths);
 


### PR DESCRIPTION
Switching the json-refs dep for two reasons:
- json-refs is not maintained anymore
- json-refs uses Node.js modules (path, querystring...) and Webpack 5 does not polyfill them anymore

Using @apidevtools/json-schema-ref-parser has been considered but [it uses Node.js modules](https://github.com/APIDevTools/json-schema-ref-parser/issues/254) too.

[jsonref](https://github.com/vivocha/jsonref) is not widely used but does not use Node.js modules (and has 0 dependency).