### PR TITLE
fix: build only esm

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,8 +10,7 @@ const config: Config.InitialOptions = {
     '^.+\\.ts$': [
       'ts-jest',
       {
-        useESM: true,
-        tsconfig: './tsconfig.esm.json',
+        useESM: true
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -7,14 +7,9 @@
     "lib",
     "src"
   ],
-  "exports": {
-    ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
-  },
-  "main": "./lib/cjs/index.js",
-  "module": "./lib/esm/index.js",
+  "type": "module",
+  "exports": "./lib/index.js",
+  "main": "./lib/index.js",
   "repository": "api-platform/api-doc-parser",
   "homepage": "https://github.com/api-platform/api-doc-parser",
   "bugs": "https://github.com/api-platform/api-doc-parser/issues",
@@ -55,7 +50,7 @@
     "lint": "esw --color src --ext .ts",
     "fix": "yarn lint --fix",
     "eslint-check": "eslint-config-prettier src/index.ts",
-    "build": "rm -rf lib/* && tsc && tsc -p tsconfig.esm.json",
+    "build": "rm -rf lib/* && tsc",
     "watch": "tsc --watch"
   },
   "sideEffects": false,

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "target": "es6",
-    "module": "esnext",
-    "outDir": "./lib/esm",
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
+    "target": "es6",
+    "module": "esnext",
+    "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "./lib/cjs",
+    "outDir": "./lib",
     "declaration": true,
     "declarationMap": true,
     "rootDir": "./src",
     "importHelpers": true,
     "strict": true,
-    "moduleResolution": "node",
     "esModuleInterop": true
   },
   "exclude": [


### PR DESCRIPTION
Since [jsonref](https://github.com/vivocha/jsonref) is already ESM only and more and more packages will be (for instance [graphql](https://github.com/graphql/graphql-js) in version 17), it doesn't make sense to build CJS and it would require to use dynamic imports for the dependencies.