### PR TITLE
Two bug fixes related to API Platform Admin

### DIFF
--- a/src/hydra/fetchJsonLd.ts
+++ b/src/hydra/fetchJsonLd.ts
@@ -2,6 +2,7 @@ import type { Document, JsonLd, RemoteDocument } from "jsonld/jsonld-spec";
 import type { RequestInitExtended } from "./types.js";
 
 const jsonLdMimeType = "application/ld+json";
+const jsonProblemMimeType = "application/problem+json";
 
 export type RejectedResponseDocument = {
   response: Response;
@@ -31,7 +32,7 @@ export default async function fetchJsonLd(
     return Promise.resolve({ response });
   }
 
-  if (500 <= status || !contentType || !contentType.includes(jsonLdMimeType)) {
+  if (500 <= status || !contentType || (!contentType.includes(jsonLdMimeType) && !contentType.includes(jsonProblemMimeType))) {
     const reason: RejectedResponseDocument = { response };
     return Promise.reject(reason);
   }

--- a/src/hydra/parseHydraDocumentation.ts
+++ b/src/hydra/parseHydraDocumentation.ts
@@ -59,7 +59,7 @@ export function getDocumentationUrlFromHeaders(headers: Headers): string {
   }
 
   const matches =
-    /<(.+)>; rel="http:\/\/www.w3.org\/ns\/hydra\/core#apiDocumentation"/.exec(
+    /<([^<]+)>; rel="http:\/\/www.w3.org\/ns\/hydra\/core#apiDocumentation"/.exec(
       linkHeader
     );
   if (matches === null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | 
| License       | MIT
| Doc PR        |

1. was not handling Content-Type: application/problem+json which is necessary for API-Platform
2. getDocumentationFromHeaders() was not extracting URL from Link, when multiple alternative urls were provided