### PR TITLE
chore: modernize package.json and TypeScript configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - pull_request
-  - push
+  pull_request:
+    branches: ["**"]
+  push:
+    branches: [main]
 
 jobs:
   ci:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,3 @@
-// @ts-check
-
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,19 +1,12 @@
-import type { Config } from "@jest/types";
+import type { JestConfigWithTsJest } from "ts-jest";
 
-const config: Config.InitialOptions = {
-  extensionsToTreatAsEsm: [".ts"],
+const config = {
+  preset: "ts-jest/presets/default-esm",
+  moduleFileExtensions: ["ts", "js"],
   setupFilesAfterEnv: ["./jest.setup.ts"],
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
-  transform: {
-    "^.+\\.ts$": [
-      "ts-jest",
-      {
-        useESM: true,
-      },
-    ],
-  },
-};
+} satisfies JestConfigWithTsJest;
 
-export default config;
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@eslint/compat": "^1.2.5",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.19.0",
+    "@jest/globals": "29.7.0",
     "@jest/types": "29.0.0",
     "@types/inflection": "^1.13.0",
     "@types/jest": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,16 @@
   "author": "Kévin Dunglas",
   "sideEffects": false,
   "type": "module",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "files": [
     "*.md",
     "lib",
@@ -29,8 +37,7 @@
     "inflection": "^3.0.0",
     "jsonld": "^8.3.2",
     "jsonref": "^9.0.0",
-    "lodash.get": "^4.4.0",
-    "tslib": "^2.0.0"
+    "lodash.get": "^4.4.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -2,19 +2,36 @@
   "name": "@api-platform/api-doc-parser",
   "version": "0.16.8",
   "description": "Transform an API documentation (Hydra, OpenAPI, GraphQL) in an intermediate representation that can be used for various tasks such as creating smart API clients, scaffolding code or building administration interfaces.",
+  "homepage": "https://github.com/api-platform/api-doc-parser",
+  "bugs": "https://github.com/api-platform/api-doc-parser/issues",
+  "repository": "api-platform/api-doc-parser",
+  "license": "MIT",
+  "author": "Kévin Dunglas",
+  "sideEffects": false,
+  "type": "module",
+  "exports": "./lib/index.js",
+  "main": "./lib/index.js",
   "files": [
     "*.md",
     "lib",
     "src"
   ],
-  "type": "module",
-  "exports": "./lib/index.js",
-  "main": "./lib/index.js",
-  "repository": "api-platform/api-doc-parser",
-  "homepage": "https://github.com/api-platform/api-doc-parser",
-  "bugs": "https://github.com/api-platform/api-doc-parser/issues",
-  "author": "Kévin Dunglas",
-  "license": "MIT",
+  "scripts": {
+    "build": "rm -rf lib/* && tsc",
+    "eslint-check": "eslint-config-prettier src/index.ts",
+    "fix": "pnpm lint --fix",
+    "lint": "eslint src",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "graphql": "^16.0.0",
+    "inflection": "^3.0.0",
+    "jsonld": "^8.3.2",
+    "jsonref": "^9.0.0",
+    "lodash.get": "^4.4.0",
+    "tslib": "^2.0.0"
+  },
   "devDependencies": {
     "@eslint/compat": "^1.2.5",
     "@eslint/eslintrc": "^3.2.0",
@@ -41,25 +58,8 @@
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.22.0"
   },
-  "dependencies": {
-    "graphql": "^16.0.0",
-    "inflection": "^3.0.0",
-    "jsonld": "^8.3.2",
-    "jsonref": "^9.0.0",
-    "lodash.get": "^4.4.0",
-    "tslib": "^2.0.0"
-  },
-  "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "lint": "eslint src",
-    "fix": "pnpm lint --fix",
-    "eslint-check": "eslint-config-prettier src/index.ts",
-    "build": "rm -rf lib/* && tsc",
-    "watch": "tsc --watch"
-  },
-  "sideEffects": false,
+  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
   "publishConfig": {
     "access": "public"
-  },
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,24 @@
   "name": "@api-platform/api-doc-parser",
   "version": "0.16.8",
   "description": "Transform an API documentation (Hydra, OpenAPI, GraphQL) in an intermediate representation that can be used for various tasks such as creating smart API clients, scaffolding code or building administration interfaces.",
+  "keywords": [
+    "api",
+    "api-platform",
+    "documentation",
+    "hydra",
+    "openapi",
+    "graphql",
+    "jsonld",
+    "json-schema",
+    "typescript",
+    "client"
+  ],
   "homepage": "https://github.com/api-platform/api-doc-parser",
   "bugs": "https://github.com/api-platform/api-doc-parser/issues",
-  "repository": "api-platform/api-doc-parser",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/api-platform/api-doc-parser.git"
+  },
   "license": "MIT",
   "author": "Kévin Dunglas",
   "sideEffects": false,
@@ -26,7 +41,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rm -rf lib tsconfig.tsbuildinfo && tsc",
+    "build": "rm -rf lib && tsc --project tsconfig.build.json",
     "build:watch": "tsc --watch",
     "eslint-check": "eslint-config-prettier src/index.ts",
     "lint": "eslint src",
@@ -69,6 +84,9 @@
     "typescript-eslint": "^8.22.0"
   },
   "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
+  "engines": {
+    "node": ">=18"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rm -rf lib/* && tsc",
+    "build": "rm -rf lib tsconfig.tsbuildinfo && tsc",
+    "build:watch": "tsc --watch",
     "eslint-check": "eslint-config-prettier src/index.ts",
-    "fix": "pnpm lint --fix",
     "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "watch": "tsc --watch"
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch"
   },
   "dependencies": {
     "graphql": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "files": [
-    "*.md",
     "lib",
-    "src"
+    "LICENSE",
+    "package.json",
+    "README.md"
   ],
   "scripts": {
     "build": "rm -rf lib/* && tsc",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       lodash.get:
         specifier: ^4.4.0
         version: 4.4.2
-      tslib:
-        specifier: ^2.0.0
-        version: 2.8.1
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.5
@@ -5177,7 +5174,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@eslint/js':
         specifier: ^9.19.0
         version: 9.28.0
+      '@jest/globals':
+        specifier: 29.7.0
+        version: 29.7.0
       '@jest/types':
         specifier: 29.0.0
         version: 29.0.0

--- a/src/hydra/fetchJsonLd.ts
+++ b/src/hydra/fetchJsonLd.ts
@@ -1,4 +1,4 @@
-import type { Document, JsonLd, RemoteDocument } from "jsonld/jsonld-spec";
+import type { Document, JsonLd, RemoteDocument } from "jsonld/jsonld-spec.js";
 import type { RequestInitExtended } from "./types.js";
 
 const jsonLdMimeType = "application/ld+json";

--- a/src/openapi3/parseOpenApi3Documentation.ts
+++ b/src/openapi3/parseOpenApi3Documentation.ts
@@ -1,7 +1,7 @@
 import { Api } from "../Api.js";
 import handleJson, { removeTrailingSlash } from "./handleJson.js";
 import type { OpenAPIV3 } from "openapi-types";
-import type { RequestInitExtended } from "./types";
+import type { RequestInitExtended } from "./types.js";
 
 export interface ParsedOpenApi3Documentation {
   api: Api;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    /* Emit */
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["./src/**/*.test.ts"]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["jest.config.ts", "jest.setup.ts", "./src"],
-  "exclude": []
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,41 @@
 {
   "compilerOptions": {
     /* Type checking */
+    // "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    // "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "strict": true,
 
     /* Modules */
-    "module": "esnext",
-    "moduleResolution": "node",
-    "rootDir": "./src",
+    "module": "NodeNext",
+    "noUncheckedSideEffectImports": true,
+    "types": ["jest"],
 
     /* Language and Environment */
-    "target": "es6",
+    "lib": ["ES2022", "DOM"],
+    "moduleDetection": "force",
+    "target": "ES2022",
+
+    /* Output Formatting */
+    "noErrorTruncation": true,
 
     /* Emit */
     "declaration": true,
     "declarationMap": true,
-    "importHelpers": true,
+    "inlineSources": true,
+    "outDir": "lib",
     "sourceMap": true,
-    "outDir": "./lib",
 
     /* Interop Constraints */
-    "esModuleInterop": true
+    // "erasableSyntaxOnly": true,
+    "isolatedDeclarations": true,
+    "verbatimModuleSyntax": true
   },
-  "exclude": [
-    "src/**/*.test.ts",
-  ],
   "include": ["./src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,24 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    /* Type checking */
+    "strict": true,
+
+    /* Modules */
     "module": "esnext",
     "moduleResolution": "node",
-    "sourceMap": true,
-    "outDir": "./lib",
+    "rootDir": "./src",
+
+    /* Language and Environment */
+    "target": "es6",
+
+    /* Emit */
     "declaration": true,
     "declarationMap": true,
-    "rootDir": "./src",
     "importHelpers": true,
-    "strict": true,
+    "sourceMap": true,
+    "outDir": "./lib",
+
+    /* Interop Constraints */
     "esModuleInterop": true
   },
   "exclude": [


### PR DESCRIPTION
## What’s in this PR?

* Re-aligns our **library build and dev setup with the 2025 TypeScript defaults**.  
* Introduces a dedicated **`tsconfig.build.json`**.  
* Switches to **`module: "NodeNext"` and modern ES2022 targets**, giving consumers first-class ESM support and smaller, helper-free output.  
* Enables the compiler options that catch the most common API-breaking mistakes (unused code, fall-through switches, mismatched casing, etc.) without resorting to a bundler.  
* Cleans up redundant or legacy flags, resulting in a clearer config that mirrors community best practices.

### Sources consulted

* Matt Pocock – TSConfig Cheat Sheet  
  https://www.totaltypescript.com/tsconfig-cheat-sheet
* TypeScript Docs – Compiler Options  
  https://www.typescriptlang.org/tsconfig
* 2ality – *“Up-to-date tsconfig.json in 2025”*  
  https://2ality.com/2025/01/tsconfig-json.html
* **@sindresorhus/tsconfig** – opinionated base config  
  https://github.com/sindresorhus/tsconfig/blob/main/tsconfig.json
* TypeScript issue #58420 
  https://github.com/microsoft/TypeScript/issues/58420
* TypeScript PR #61813
  https://github.com/microsoft/TypeScript/pull/61813

## Changelog

### 🐛 fix
- ci: prevent duplicated CI run on pull requests  
- imports: add .js extension to imports  

### 📦 build
- package.json: add keywords and update repository metadata  
- package.json: update scripts (add typecheck[:watch], rename fix→lint:fix, rename watch→build:watch) and clean `tsconfig.tsbuildinfo` on build  
- package.json: refine `files` list (remove `src`, add LICENSE, include only README.md)  
- package.json: restructure `exports` and add type definitions  
- tsconfig.ts: modernize and improve compiler options  
- tsconfig.ts: sort and categorize compiler options  

### 🚨 test
- jest: update config and add `@jest/globals` dev dependency  

### 🧹 chore
- package.json: apply `sort-package-json`  

Blocked by #149 