### PR TITLE
Fix missing default "Accept" header if options.headers is falsy

### DIFF
--- a/src/hydra/fetchJsonLd.ts
+++ b/src/hydra/fetchJsonLd.ts
@@ -62,7 +62,7 @@ export default async function fetchJsonLd(
 
 function setHeaders(options: RequestInitExtended): RequestInit {
   if (!options.headers) {
-    return { ...options, headers: {} };
+    options.headers = {};
   }
 
   let headers =


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | main
| License       | MIT

`schemaAnalyzer.resolveSchemaParameters()` calls `schema.getParameters()` without `options` argument (which defaults to `{}`)
https://github.com/api-platform/admin/blob/ab9239cc0b750ad9339de0bc856031b0da47dc38/src/introspection/schemaAnalyzer.ts#L14:L16

From now on the empty `options` object gets passed `getParameters()` -> `fetchResource()` -> `fetchJsonLd()` -> `setHeaders()`

https://github.com/api-platform/api-doc-parser/blob/1f6772b96936030ea4308efd04d0f69de5a24482/src/hydra/getParameters.ts#L10

https://github.com/api-platform/api-doc-parser/blob/1f6772b96936030ea4308efd04d0f69de5a24482/src/hydra/fetchResource.ts#L9:L13

https://github.com/api-platform/api-doc-parser/blob/1f6772b96936030ea4308efd04d0f69de5a24482/src/hydra/fetchJsonLd.ts#L30

The first `if` in `setHeaders()` returns early without any headers, if `options.headers` is falsy - what is always the case when the options object is empty itself. So the default "Accept" header will not be set.

https://github.com/api-platform/api-doc-parser/blob/1f6772b96936030ea4308efd04d0f69de5a24482/src/hydra/fetchJsonLd.ts#L64:L66

