### PR TITLE
Fix missing default Accept header when options is an empty object

### DIFF
--- a/src/hydra/fetchJsonLd.test.ts
+++ b/src/hydra/fetchJsonLd.test.ts
@@ -154,6 +154,40 @@ test("fetch an error with Content-Type application/error+json", async () => {
   );
 });
 
+test("fetch with an explicit empty options object still sends the default Accept header", async () => {
+  let receivedAccept: string | null = null;
+
+  server.use(
+    http.get("http://localhost/foo.jsonld", ({ request }) => {
+      receivedAccept = request.headers.get("Accept");
+      return Response.json(httpResponse, {
+        headers: { "Content-Type": "application/ld+json" },
+        status: 200,
+        statusText: "OK",
+      });
+    }),
+  );
+
+  await fetchJsonLd("http://localhost/foo.jsonld", {});
+  expect(receivedAccept).toBe("application/ld+json");
+});
+
+test("fetch does not mutate the passed options object", async () => {
+  server.use(
+    http.get("http://localhost/foo.jsonld", () =>
+      Response.json(httpResponse, {
+        headers: { "Content-Type": "application/ld+json" },
+        status: 200,
+        statusText: "OK",
+      }),
+    ),
+  );
+
+  const options = {};
+  await fetchJsonLd("http://localhost/foo.jsonld", options);
+  expect(options).toEqual({});
+});
+
 test("fetch an empty document", async () => {
   server.use(
     http.get(

--- a/src/hydra/fetchJsonLd.ts
+++ b/src/hydra/fetchJsonLd.ts
@@ -61,12 +61,10 @@ export default async function fetchJsonLd(
 }
 
 function setHeaders(options: RequestInitExtended): RequestInit {
-  if (!options.headers) {
-    return { ...options, headers: {} };
-  }
-
   let headers =
-    typeof options.headers === "function" ? options.headers() : options.headers;
+    typeof options.headers === "function"
+      ? options.headers()
+      : (options.headers ?? {});
 
   headers = new Headers(headers);
 


### PR DESCRIPTION
## Summary

Alternative fix for #177.

`setHeaders()` short-circuited on falsy `options.headers`, returning a plain `{}` instead of building `Headers` with the `Accept` default. This breaks `@api-platform/admin`'s `schemaAnalyzer.resolveSchemaParameters()`, which always calls `getParameters()` with an explicit `{}`.

#177's fix (`options.headers = {}` instead of `return`) works, but mutates the caller-supplied `options` object as a side effect before falling through. This PR removes the early-return branch entirely and derives `headers` without mutating the input:

```ts
let headers =
  typeof options.headers === "function"
    ? options.headers()
    : (options.headers ?? {});
```

- No mutation of the caller's `options` object.
- Added a regression test asserting the default `Accept` header is sent when `options` is `{}`.
- Added a test asserting `fetchJsonLd` does not mutate the passed `options` object.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [ ] `pnpm test src/hydra/fetchJsonLd.test.ts` (blocked locally by unrelated stray Yarn PnP files in this checkout; relying on CI)