### PR TITLE
fix(hydra): deduplicate resource parameter discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ interface Resource {
 }
 ```
 
+For Hydra resources, `getParameters()` loads parameters lazily and caches the
+result for the lifetime of the `Resource` instance. Run the documentation
+parser again to refresh parameters after the API schema or authorization
+context changes.
+
 ### Field
 
 Represents a property of a resource, including its type, constraints, and metadata.

--- a/src/hydra/fetchResource.ts
+++ b/src/hydra/fetchResource.ts
@@ -6,11 +6,7 @@ export default async function fetchResource(
   resourceUrl: string,
   options: RequestInitExtended = {},
 ): Promise<{ parameters: IriTemplateMapping[] }> {
-  const response = await fetchJsonLd(
-    resourceUrl,
-    // oxlint-disable-next-line prefer-object-spread
-    Object.assign({ itemsPerPage: 0 }, options),
-  );
+  const response = await fetchJsonLd(resourceUrl, options);
 
   let hasPrefix = true;
   if ("body" in response) {

--- a/src/hydra/getParameters.test.ts
+++ b/src/hydra/getParameters.test.ts
@@ -1,0 +1,132 @@
+import { http } from "msw/core/http";
+import { expect, test } from "vitest";
+import { server } from "../../vitest.setup.js";
+import { Field, Resource } from "../core/index.js";
+import getParameters from "./getParameters.js";
+
+const init = {
+  headers: { "Content-Type": "application/ld+json" },
+  status: 200,
+  statusText: "OK",
+};
+
+const resourceCollectionWithParameters = {
+  "hydra:search": {
+    "hydra:mapping": [
+      {
+        property: "isbn",
+        variable: "isbn",
+        required: false,
+      },
+    ],
+  },
+};
+
+function createResource(): Resource {
+  return new Resource("books", "http://localhost/books", {
+    fields: [
+      new Field("isbn", {
+        range: "http://www.w3.org/2001/XMLSchema#string",
+      }),
+    ],
+  });
+}
+
+test("Resource parameters are cached and concurrent requests are deduplicated", async () => {
+  let discoveryRequests = 0;
+  server.use(
+    http.get("http://localhost/books", () => {
+      discoveryRequests += 1;
+      return Response.json(resourceCollectionWithParameters, init);
+    }),
+  );
+  const resource = createResource();
+
+  const firstRequest = getParameters(resource);
+  const concurrentRequest = getParameters(resource);
+
+  expect(concurrentRequest).toBe(firstRequest);
+
+  const parameters = await firstRequest;
+  const cachedParameters = await getParameters(resource);
+
+  expect(cachedParameters).toBe(parameters);
+  expect(resource.parameters).toBe(parameters);
+  expect(discoveryRequests).toBe(1);
+  expect(parameters).toEqual([
+    {
+      description: "",
+      range: "http://www.w3.org/2001/XMLSchema#string",
+      required: false,
+      variable: "isbn",
+    },
+  ]);
+});
+
+test("Empty resource parameters are cached", async () => {
+  let discoveryRequests = 0;
+  server.use(
+    http.get("http://localhost/books", () => {
+      discoveryRequests += 1;
+      return Response.json({}, init);
+    }),
+  );
+  const resource = createResource();
+
+  const parameters = await getParameters(resource);
+  const cachedParameters = await getParameters(resource);
+
+  expect(parameters).toEqual([]);
+  expect(cachedParameters).toBe(parameters);
+  expect(discoveryRequests).toBe(1);
+});
+
+test("Resource parameters can be retried after a failed request", async () => {
+  let attempts = 0;
+  server.use(
+    http.get("http://localhost/books", () => {
+      attempts += 1;
+      return new Response(null, { status: 500 });
+    }),
+  );
+  const resource = createResource();
+
+  await expect(getParameters(resource)).rejects.toBeDefined();
+
+  server.use(
+    http.get("http://localhost/books", () => {
+      attempts += 1;
+      return Response.json(resourceCollectionWithParameters, init);
+    }),
+  );
+
+  await expect(getParameters(resource)).resolves.toEqual([
+    {
+      description: "",
+      range: "http://www.w3.org/2001/XMLSchema#string",
+      required: false,
+      variable: "isbn",
+    },
+  ]);
+  expect(attempts).toBe(2);
+});
+
+test("Parameter caches are isolated between Resource instances", async () => {
+  let discoveryRequests = 0;
+  server.use(
+    http.get("http://localhost/books", () => {
+      discoveryRequests += 1;
+      return Response.json(resourceCollectionWithParameters, init);
+    }),
+  );
+  const firstResource = createResource();
+  const secondResource = createResource();
+
+  expect(firstResource.url).toBe(secondResource.url);
+
+  await getParameters(firstResource);
+  await getParameters(firstResource);
+  await getParameters(secondResource);
+
+  expect(discoveryRequests).toBe(2);
+});

--- a/src/hydra/getParameters.ts
+++ b/src/hydra/getParameters.ts
@@ -3,23 +3,52 @@ import { Parameter } from "../core/index.js";
 import type { RequestInitExtended } from "../core/types.js";
 import fetchResource from "./fetchResource.js";
 
-export default async function getParameters(
+const parametersPromises = new WeakMap<Resource, Promise<Parameter[]>>();
+
+/**
+ * Gets and caches parameters for the lifetime of a Resource instance.
+ * Rejected requests are not cached and can be retried.
+ * @param {Resource} resource The resource whose parameters should be loaded.
+ * @param {RequestInitExtended} [options] Optional fetch options.
+ * @returns {Promise<Parameter[]>} The cached or newly loaded parameters.
+ */
+export default function getParameters(
   resource: Resource,
   options: RequestInitExtended = {},
 ): Promise<Parameter[]> {
-  const { parameters = [] } = await fetchResource(resource.url, options);
-  const resourceParameters: Parameter[] = [];
-  for (const { property = null, required, variable } of parameters) {
-    if (property === null) {
-      continue;
-    }
-
-    const { range = null } =
-      resource.fields?.find(({ name }) => property === name) || {};
-
-    resourceParameters.push(new Parameter(variable, range, required, ""));
+  const cachedPromise = parametersPromises.get(resource);
+  if (cachedPromise !== undefined) {
+    return cachedPromise;
   }
-  resource.parameters = resourceParameters;
 
-  return resourceParameters;
+  const parametersPromise = loadParameters(resource, options);
+  parametersPromises.set(resource, parametersPromise);
+
+  return parametersPromise;
+}
+
+async function loadParameters(
+  resource: Resource,
+  options: RequestInitExtended,
+): Promise<Parameter[]> {
+  try {
+    const { parameters = [] } = await fetchResource(resource.url, options);
+    const resourceParameters: Parameter[] = [];
+    for (const { property = null, required, variable } of parameters) {
+      if (property === null) {
+        continue;
+      }
+
+      const { range = null } =
+        resource.fields?.find(({ name }) => property === name) || {};
+
+      resourceParameters.push(new Parameter(variable, range, required, ""));
+    }
+    resource.parameters = resourceParameters;
+
+    return resourceParameters;
+  } catch (error: unknown) {
+    parametersPromises.delete(resource);
+    throw error;
+  }
 }

--- a/src/hydra/parseHydraDocumentation.test.ts
+++ b/src/hydra/parseHydraDocumentation.test.ts
@@ -1589,7 +1589,11 @@ test("Resource parameters can be retrieved", async () => {
   assert(!!resource.getParameters);
 
   const parameters = await resource.getParameters();
+
   expect(fetchSpy).toHaveBeenCalledTimes(3);
+  expect(fetchSpy).toHaveBeenLastCalledWith("http://localhost/books", {
+    headers: {},
+  });
   expect(parameters).toEqual([
     {
       description: "",
@@ -1598,6 +1602,7 @@ test("Resource parameters can be retrieved", async () => {
       variable: "isbn",
     },
   ]);
+  fetchSpy.mockRestore();
 });
 
 test("parse a Hydra documentation with enum/read-only resources (rdfs:range direct @id)", async () => {

--- a/src/hydra/parseHydraDocumentation.ts
+++ b/src/hydra/parseHydraDocumentation.ts
@@ -549,7 +549,8 @@ export default async function parseHydraDocumentation(
     resource.parameters = [];
     resource.getParameters =
       /**
-       * Gets the parameters for the resource.
+       * Gets the parameters for the resource. The result is cached for the
+       * lifetime of this Resource instance.
        * @returns {Promise<Parameter[]>} The parameters for the resource.
        */
       (): Promise<Parameter[]> => getParameters(resource, options);


### PR DESCRIPTION
## Summary

- remove the unsupported `itemsPerPage` property passed to `fetch`
- cache Hydra resource parameter discovery per `Resource` instance
- deduplicate concurrent parameter requests
- cache successful empty results
- evict rejected requests from the cache to allow retries
- document the cache lifetime

## Context

Hydra resource parameters are discovered by requesting the collection endpoint
and reading its `hydra:search` mapping.

The parser previously passed `itemsPerPage` as a `RequestInit` property. This
property is not supported by `fetch` and was silently ignored. In addition,
concurrent calls to `getParameters()` or repeated calls returning no parameters
could trigger multiple identical collection requests.

The result is now stored in a `WeakMap` keyed by the `Resource` instance. This
keeps caches isolated between documentation parses and allows entries to be
garbage-collected with their resource.

Rejected requests are removed from the cache so that a later call can retry.

This change does not remove the initial Hydra discovery request or assume an
API Platform-specific pagination parameter. It prevents repeated discovery
requests in a generic way.

Related to https://github.com/api-platform/api-doc-parser/issues/115.
Related to https://github.com/api-platform/admin/issues/508.

## Tests

Added dedicated coverage for:

- successful caching and concurrent request deduplication
- empty parameter results
- retries after a failed request
- cache isolation between resources sharing the same URL

The parser test retains integration coverage for wiring `getParameters()` and
the resulting fetch request.

Validation:

- 30 tests passing
- TypeScript typecheck
- Oxlint
- Prettier
- `git diff --check`
